### PR TITLE
Initialise .gitconfig

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -1,0 +1,7 @@
+[user]
+	email = %email%
+	name = %name%
+[core]
+	editor = vim
+[credential]
+	helper = store

--- a/home/.vimrc
+++ b/home/.vimrc
@@ -1,2 +1,3 @@
-set expandtab
 set tabstop=2
+set shiftwidth=2
+set expandtab

--- a/install.sh
+++ b/install.sh
@@ -30,14 +30,16 @@ sudo nixos-install
 # Create user
 
 echo Enter your details to create your user account
-echo -n "Your full name: "
-read name
-echo -n "Account name for login: "
-read login
+read -p "Your full name: " name
+read -p "Account name for login: " login
+read -p "Your e-mail address (for your Git identity): " email
 
 sudo nixos-enter --command "useradd --comment '$name' --create-home $login; passwd $login"
 
 curl --location https://api.github.com/repos/nicholaslawton/nickos/tarball | \
   tar --extract --gunzip --directory /mnt/home/$login --wildcards "*/home" --strip-components=2
+
+sed --in-place "s/%name%/$name/" /mnt/home/$login/.gitconfig
+sed --in-place "s/%email%/$email/" /mnt/home/$login/.gitconfig
 
 reboot

--- a/iso/bootstrap/bin/nickos-bootstrap.sh
+++ b/iso/bootstrap/bin/nickos-bootstrap.sh
@@ -1,10 +1,8 @@
 # Connect to WiFi
 
 echo Enter your WiFi network details
-echo -n "Network name: "
-read ssid
-echo -n "Password: "
-read psk
+read -p "Network name: " ssid
+read -p "Password: " psk
 
 echo wpa_supplicant
 sudo systemctl start wpa_supplicant


### PR DESCRIPTION
Initialises Git config with identity, and preferred editor and credential helper. Installation prompts for email address and substitutes that and name into the Git identity.