### PR TITLE
Reorganise configuration

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v15
       with:
-        nix_path: nixpkgs=channel:nixos-21.11
+        nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-build iso
     - uses: actions/upload-artifact@v3
       with:

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -12,16 +12,9 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
-  # networking.hostName = "nixos"; # Define your hostname.
-  networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
-  networking.wireless.networks = import ./networking-wireless-networks.nix;
+  networking = import ./networking.nix;
 
-  #users.users.nicholas = {
-  #  isNormalUser = true;
-  #  home = "/home/nicholas";
-  #  description = "Nicholas Lawton";
-  #  extraGroups = [ "wheel" ];
-  #};
+  users = import ./users.nix;
 
   # Set your time zone.
   # time.timeZone = "Europe/Amsterdam";
@@ -72,6 +65,7 @@
   # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [
+    nushell
     vim
     git
   ];

--- a/nixos/networking.nix
+++ b/nixos/networking.nix
@@ -1,0 +1,9 @@
+{
+  hostName = "nickos";
+  wireless.enable = true;
+  wireless.networks = {
+    %ssid% = {
+      psk = "%psk%";
+    };
+  };
+}

--- a/nixos/users.nix
+++ b/nixos/users.nix
@@ -1,0 +1,8 @@
+{
+  users.%account% = {
+    isNormalUser = true;
+    home = "/home/$account%";
+    description = "%name%";
+    extraGroups = [ "wheel" ];
+  }
+}


### PR DESCRIPTION
Reorganises the configuration for the installation process, using substitution. Switches to declarative user definition, to grant `sudo` access.